### PR TITLE
adjust for bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,27 @@ Objective of such structure:
 ## Scripting functionality
 
 Check [eurobench_tooling/README.md](eurobench_tooling/README.md).
+
+## Advancement
+
+[General template sheet](https://drive.google.com/drive/u/0/folders/186_p3bJVd_ugNNAe3cgfW72ZDYCC8oIy)
+
+* **beast**:
+  * [code](https://docs.google.com/spreadsheets/d/1Wp9QYMm_V1tOCheF185pOYPcIm9yt6AU/edit?rtpof=true)
+  * docker:
+  * yaml:
+  * excel:
+  * current state: ready for database trial
+* **beat**:
+  * [code](https://docs.google.com/spreadsheets/d/16fQ5ReesRFfUHpOVV2ekaKSuec2XO0-H/edit?rtpof=true)
+  * docker:
+  * yaml:
+  * excel:
+  * current state: waiting for PI output adjustment in code.
+* **bullet**:
+  * [code](https://github.com/eurobench/pi_bullet)
+  * [yaml](data/bullet.yaml)
+  * excels:
+    * [walking](https://docs.google.com/spreadsheets/d/1BPKyCwdTW-pmccuSc34m4ZglnibAZeu4/edit#gid=766575927)
+    * [walking_complete](https://docs.google.com/spreadsheets/d/1rAJXqnzodYghTHCIcKvOM6r8MwtHygkn/edit#gid=716373661)
+  * current state: ready for database trial

--- a/data/bullet.yaml
+++ b/data/bullet.yaml
@@ -169,7 +169,7 @@ pi:
     inter_run_aggregation: [0, mean, st_dev]
     visu: boxplot
     inter_cond_aggregation: undef
-    inter_subject_aggregation: [mean, std_dev]
+    inter_subject_aggregation: [0, mean, std_dev]
   - name: rms_load_right
     name_readable: "Right load Root Mean Square"
     description: "Root mean square value of the right crutch force"
@@ -268,15 +268,14 @@ pi_algo:
       - stance_time_left
       - stance_time_right
     input_files:
-      - subject_N_run_R_wrench_CrutchLeft.csv
-      - subject_N_run_R_wrench_CrutchRight.csv
-      - subject_N_run_R_gaitEvents.yaml
+      - wrench_CrutchLeft.csv
+      - wrench_CrutchRight.csv
+      - gaitEvents.yaml
     input_command:
       - ./run_pi_BulletWalking
-      - subject_N_run_R_wrench_CrutchLeft.csv
-      - subject_N_run_R_wrench_CrutchRight.csv
-      - subject_N_run_R_gaitEvents.yaml
-      - outputDir
+      - wrench_CrutchLeft.csv
+      - wrench_CrutchRight.csv
+      - gaitEvents.yaml
     language: octave
   - name: pi_bullet_walking_complete
     description: Algorithm for analysis of gait performed with instrumented
@@ -300,17 +299,16 @@ pi_algo:
     # I suggest stating only wrench_CrutchLeft
     # Alfonso suggests crutchLeft_wrench
     input_files:
-      - subject_N_run_R_wrench_CrutchLeft.csv
-      - subject_N_run_R_wrench_CrutchRight.csv
-      - subject_N_run_R_gaitEvents.yaml
-      - subject_N_run_R_wrench_ShoulderLeft.csv
-      - subject_N_run_R_wrench_ShoulderRight.csv
+      - wrench_CrutchLeft.csv
+      - wrench_CrutchRight.csv
+      - gaitEvents.yaml
+      - wrench_ShoulderLeft.csv
+      - wrench_ShoulderRight.csv
     input_command:
       - ./run_pi_BulletWalkingComplete
-      - subject_N_run_R_wrench_CrutchLeft.csv
-      - subject_N_run_R_wrench_CrutchRight.csv
-      - subject_N_run_R_gaitEvents.yaml
-      - subject_N_run_R_wrench_ShoulderLeft.csv
-      - subject_N_run_R_wrench_ShoulderRight.csv
-      - outputDir
+      - wrench_CrutchLeft.csv
+      - wrench_CrutchRight.csv
+      - gaitEvents.yaml
+      - wrench_ShoulderLeft.csv
+      - wrench_ShoulderRight.csv
     language: octave

--- a/eurobench_tooling/eurobench_tooling/content_checker.py
+++ b/eurobench_tooling/eurobench_tooling/content_checker.py
@@ -98,8 +98,17 @@ def check_algo_input(spec):
   all_ok = True
   for item in linput:
     if item not in config.EurobenchConfig.input_type:
-      print(colored('Unknown input file: {}'.format(item), 'red'))
-      all_ok = False
+      # print(colored("Issue with {}".format(item), 'yellow'))
+      # check if this something like knownTag_additionalTerm
+      item_name, item_extension = os.path.splitext(item)
+      item_name = item_name.split('_')
+      item_root = item_name[0] + item_extension
+      # print("root_item: {}".format(item_root))
+      if item_root in config.EurobenchConfig.input_type:
+        print(colored('item {} considered as {}'.format(item, item_root), 'yellow'))
+      else:
+        print(colored('Unknown input file: {}'.format(item), 'red'))
+        all_ok = False
 
   return all_ok
 
@@ -141,4 +150,8 @@ def main():
   if not check_algo_pi_connection(spec):
     all_ok = False
 
+  if all_ok:
+    print(colored("Spec seems good", 'green'))
+  else:
+    print(colored("Component to be verified", 'red'))
   return all_ok


### PR DESCRIPTION
FYI @alfonsotecnalia 

Adjustment in `bullet`. 
I added the format `gaitEvents.yaml`. We now have 2: gait.yaml, and this one.
Started to put some info in the root readme about the status of the integration as well.

I added more check in the input file, to detect `wrench_whatever.csv` to be recognized as  format wrench.csv

Appart from the aggregation part, bullet would be ready.
I would eventually suggest adjusting the aggregation to something we can easily handle.